### PR TITLE
Remove emoji flags from language selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,10 +245,10 @@
                         </button>
                         <div class="absolute right-0 mt-2 w-36 bg-white shadow-lg rounded-md overflow-hidden opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 z-50">
                             <a href="#" class="language-option block px-4 py-2 text-sm hover:bg-sky-100 hover:text-primary transition-all duration-200 flex items-center" data-lang="en">
-                                <span class="w-6 inline-block" aria-hidden="true">🇬🇧</span> English
+                                English
                             </a>
                             <a href="#" class="language-option block px-4 py-2 text-sm hover:bg-sky-100 hover:text-primary transition-all duration-200 flex items-center" data-lang="zh">
-                                <span class="w-6 inline-block" aria-hidden="true">🇨🇳</span> 中文
+                                中文
                             </a>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- keep English as the initial language
- remove emoji flags from the language switcher

## Testing
- `npm test` *(fails: missing `package.json`)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_688c1a5c3314832e8a70691fc6e44457