### PR TITLE
fix: load splash logo locally

### DIFF
--- a/index.html
+++ b/index.html
@@ -315,7 +315,7 @@
 
     <!-- Splash Screen -->
     <div id="splash-screen" class="fixed inset-0 bg-secondary flex items-center justify-center z-[100]">
-        <img id="splash-logo" src="https://raw.githubusercontent.com/Eddie-CS/666/main/logo%E6%97%A0R.png" alt="SINNKAWA® Logo" class="h-40">
+        <img id="splash-logo" src="LOGO无R.png" alt="SINNKAWA® Logo" class="h-40">
         <p id="splash-text" class="absolute bottom-20 text-2xl font-bold text-primary opacity-0" data-i18n-key="splash_text"></p>
     </div>
 
@@ -335,7 +335,7 @@
             <div class="flex justify-between items-center h-20 md:h-24">
                 <!-- Logo -->
                 <a href="#" class="flex-shrink-0">
-                    <img src="https://raw.githubusercontent.com/Eddie-CS/666/main/logo%E6%97%A0R.png" alt="SINNKAWA® Logo" class="h-20 md:h-24">
+                    <img src="LOGO无R.png" alt="SINNKAWA® Logo" class="h-20 md:h-24">
                 </a>
 
                 <!-- Main Navigation -->


### PR DESCRIPTION
## Summary
- load splash and header logos from local file instead of external URL

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6890840c804c832eb2b6f9d6d53ecf62