### PR TITLE
Use website thumbnail for mobile character icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <meta name="keywords" content="SINNKAWA, Singapore, travel, gifts, character, IP, Chinatown, Haji Lane, cafe, Merlion, Otata">
     <meta name="author" content="SINNKAWA®">
     <!-- Favicon -->
-    <link rel="icon" href="https://raw.githubusercontent.com/Eddie-CS/666/main/favicon.png" type="image/png">
+    <link rel="icon" href="网站缩略图.png" type="image/png">
 
     <!-- Stylesheets -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/font-awesome@4.7.0/css/font-awesome.min.css">
@@ -590,7 +590,7 @@
                 <span class="text-xs mt-1" data-i18n-key="mobile_nav_explore">Explore</span>
             </a>
             <a href="#characters" class="flex flex-col items-center text-muted hover:text-primary transition-colors">
-                <img src="https://raw.githubusercontent.com/Eddie-CS/666/main/favicon.png" class="h-6 w-6" alt="Characters">
+                <img src="网站缩略图.png" class="h-6 w-6" alt="Characters">
                 <span class="text-xs mt-1" data-i18n-key="nav_characters">Characters</span>
             </a>
             <a href="#products" class="flex flex-col items-center text-muted hover:text-primary transition-colors">


### PR DESCRIPTION
## Summary
- switch favicon to local `网站缩略图.png`
- show same thumbnail icon for the characters tab in mobile navigation

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689184cc8784832e82614f547188d1a2