### PR TITLE
style: enhance hero text visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@
             content: "";
             position: absolute;
             inset: 0;
-            background: rgba(255, 255, 255, 0.3);
+            background: rgba(0, 0, 0, 0.4);
             backdrop-filter: blur(8px);
             -webkit-backdrop-filter: blur(8px);
             z-index: 5;
@@ -402,8 +402,8 @@
             <div class="container mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
                 <div class="flex flex-col lg:flex-row items-center">
                     <div class="lg:w-1/2 text-center lg:text-left mb-10 lg:mb-0 fade-in">
-                        <h1 class="text-[clamp(2.2rem,5vw,3.5rem)] font-display font-bold text-dark leading-tight mb-6" data-i18n-key="hero_title_main"></h1>
-                        <p class="text-[clamp(1rem,2vw,1.25rem)] text-muted max-w-xl mx-auto lg:mx-0 mb-8" data-i18n-key="hero_subtitle"></p>
+                        <h1 class="text-[clamp(2.2rem,5vw,3.5rem)] font-display font-bold text-white drop-shadow-lg leading-tight mb-6" data-i18n-key="hero_title_main"></h1>
+                        <p class="text-[clamp(1rem,2vw,1.25rem)] text-white drop-shadow-md max-w-xl mx-auto lg:mx-0 mb-8" data-i18n-key="hero_subtitle"></p>
                         <div class="flex flex-col sm:flex-row justify-center lg:justify-start gap-4">
                             <a href="#stores" class="inline-block bg-primary hover:bg-primary-hover text-white font-semibold px-8 py-3 rounded-full transition-all duration-200 transform hover:scale-105 hover:shadow-lg" data-i18n-key="hero_cta_explore"></a>
                         </div>


### PR DESCRIPTION
## Summary
- make hero heading and subtitle white with drop shadows
- darken hero overlay for improved contrast

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6891c3c68c40832eb044d27adf9da60d